### PR TITLE
41 add encryption to secret key file

### DIFF
--- a/seedelf-cli/README.md
+++ b/seedelf-cli/README.md
@@ -54,8 +54,14 @@ Options:
 
 ### Basic Usage
 
+Get started with the wallet using the `welcome` command.
+
+```bash
+seedelf-cli welcome
+```
+
 Create a Seedelf with the `create` command. The Seedelf is funded with the `fund` command. Send funds to another Seedelf with the `transfer` command. Funds can be send to an address with the `sweep` command. Use the `--help` option to see more information.
 
 **Some commands will prompt to open a localhost for cip30 wallet interaction.**
 
-The wallet will create a secret key file on the local machine inside the home directory under the .seedelf folder. The wallet will prompt the user at first use to name the secrey key file. Keep this file safe!
+The wallet will create an encrypted secret key file on the local machine inside the home directory under the `$HOME/.seedelf` folder. The wallet will prompt the user for a password and a name for the secrey key file. Keep this file safe!

--- a/seedelf-cli/src/commands/balance.rs
+++ b/seedelf-cli/src/commands/balance.rs
@@ -2,7 +2,6 @@ use blstrs::Scalar;
 use reqwest::Error;
 use seedelf_cli::display;
 use seedelf_cli::koios::UtxoResponse;
-use seedelf_cli::register::Register;
 use seedelf_cli::setup;
 use seedelf_cli::utxos;
 
@@ -13,14 +12,7 @@ pub async fn run(network_flag: bool) -> Result<(), Error> {
     println!("\nSeedelf Wallet Information");
     
     let scalar: Scalar = setup::load_wallet();
-    println!("\nSecret Key:\n");
-    println!("{}", scalar);
     
-    let datum: Register = Register::create(scalar);
-    println!("\nBase Register:\n");
-    println!("Generator: {}", datum.generator);
-    println!("Public Value: {}", datum.public_value);
-
     display::all_seedelfs(scalar, network_flag).await;
 
     let all_utxos: Vec<UtxoResponse> = utxos::collect_all_wallet_utxos(scalar, network_flag).await;

--- a/seedelf-cli/src/commands/welcome.rs
+++ b/seedelf-cli/src/commands/welcome.rs
@@ -3,5 +3,5 @@ pub fn run() {
     println!("\nYour wallet file is stored in the home directory in the .seedelf folder 📁. Keep this file safe!");
     println!("\nSeedelf is a stealth wallet that hides the receiver and spender using a non-interactive variant of Schnorr's Σ-protocol for the Discrete Logarithm Relation.");
     println!("\n");
-    println!("Start your journey by creating a Seedelf with the cli command: seedelf-new 😀")
+    println!("😀 Start your journey by creating a Seedelf with the cli command: create")
 }

--- a/seedelf-cli/src/setup.rs
+++ b/seedelf-cli/src/setup.rs
@@ -94,7 +94,7 @@ fn create_wallet(wallet_path: &PathBuf) {
     }
 
     let salt: SaltString = SaltString::generate(&mut OsRng);
-    let mut output_key_material: [u8; 32] = [0u8; 32]; // Can be any desired size
+    let mut output_key_material: [u8; 32] = [0u8; 32];
     let _ = Argon2::default().hash_password_into(
         password.as_bytes(),
         salt.to_string().as_bytes(),

--- a/seedelf-cli/src/setup.rs
+++ b/seedelf-cli/src/setup.rs
@@ -1,16 +1,31 @@
+use crate::schnorr::random_scalar;
 use blstrs::Scalar;
 use ff::PrimeField;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use crate::schnorr::random_scalar;
 
+use aes_gcm::aead::{Aead, AeadCore, KeyInit};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use argon2::{password_hash::SaltString, Argon2};
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use rand_core::OsRng;
+use rpassword::read_password;
 
 /// Data structure for storing wallet information
 #[derive(Serialize, Deserialize)]
 struct Wallet {
     private_key: String, // Store the scalar as a hex string
+}
+
+/// Data structure for storing wallet information
+#[derive(Serialize, Deserialize)]
+struct EncryptedData {
+    salt: String,
+    nonce: String,
+    data: String,
 }
 
 /// Check if `.seedelf` exists, create it if it doesn't, and handle file logic
@@ -46,7 +61,7 @@ pub fn check_and_prepare_seedelf() {
 /// Prompt the user to enter a wallet name
 fn prompt_wallet_name() -> String {
     let mut wallet_name = String::new();
-    print!("Enter a wallet name: ");
+    println!("\nEnter a wallet name: ");
     io::stdout().flush().unwrap();
     io::stdin()
         .read_line(&mut wallet_name)
@@ -65,13 +80,51 @@ fn create_wallet(wallet_path: &PathBuf) {
     let wallet: Wallet = Wallet {
         private_key: private_key_hex,
     };
-    let wallet_data: String = serde_json::to_string_pretty(&wallet).expect("Failed to serialize wallet");
+    let wallet_data: String =
+        serde_json::to_string_pretty(&wallet).expect("Failed to serialize wallet");
+
+    // Prompt user for an encryption password
+    println!("\nEnter a password to encrypt the wallet file:");
+    let password: String = read_password().expect("Failed to read password");
+    println!("Re-enter the password:");
+    let password_copy: String = read_password().expect("Failed to read password");
+    if password != password_copy {
+        println!("Passwords do not match; try again!");
+        create_wallet(wallet_path);
+    }
+
+    let salt: SaltString = SaltString::generate(&mut OsRng);
+    let mut output_key_material: [u8; 32] = [0u8; 32]; // Can be any desired size
+    let _ = Argon2::default().hash_password_into(
+        password.as_bytes(),
+        salt.to_string().as_bytes(),
+        &mut output_key_material,
+    );
+
+    // let key: &Key<Aes256Gcm> = output_key_material.into();
+    // let key = Key::from_slice(&output_key_material);
+    let key = Key::<Aes256Gcm>::from_slice(&output_key_material);
+    let cipher = Aes256Gcm::new(&key);
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+
+    // let nonce = Nonce::from_slice();
+    let encrypted_data = cipher
+        .encrypt(&nonce, wallet_data.as_bytes())
+        .expect("Encryption failed");
+
+    // Save encrypted data, salt, and nonce as JSON
+    let output: EncryptedData = EncryptedData {
+        salt: salt.as_str().to_string(),
+        nonce: STANDARD.encode(nonce),
+        data: STANDARD.encode(encrypted_data),
+    };
+    let output_data: String =
+        serde_json::to_string_pretty(&output).expect("Failed to serialize wallet");
 
     // Save to file
-    fs::write(wallet_path, wallet_data).expect("Failed to write wallet file");
+    fs::write(wallet_path, output_data).expect("Failed to write wallet file");
     println!("Wallet created at: {}", wallet_path.display());
 }
-
 
 /// Load the wallet file and deserialize the private key into a Scalar
 pub fn load_wallet() -> Scalar {
@@ -96,13 +149,54 @@ pub fn load_wallet() -> Scalar {
     let wallet_data: String = fs::read_to_string(&wallet_path).expect("Failed to read wallet file");
 
     // Deserialize the wallet JSON
-    let wallet: Wallet = serde_json::from_str(&wallet_data).expect("Failed to parse wallet JSON");
+    let encrypted_wallet: EncryptedData =
+        serde_json::from_str(&wallet_data).expect("Failed to parse wallet JSON");
 
-    // Decode the hex string back into bytes
-    let private_key_bytes: Vec<u8> =
-        hex::decode(wallet.private_key).expect("Failed to decode private key hex");
+    // Prompt user for the decryption password
+    println!("\nEnter the password to decrypt the wallet file:");
+    let password: String = read_password().expect("Failed to read password");
 
-    // Convert bytes to Scalar
-    Scalar::from_repr(private_key_bytes.try_into().expect("Invalid key length"))
-        .expect("Failed to reconstruct Scalar from bytes")
+    // Derive the decryption key using the provided salt
+    let salt: SaltString =
+        SaltString::from_b64(&encrypted_wallet.salt).expect("Invalid salt format");
+    let mut output_key_material: [u8; 32] = [0u8; 32];
+    let _ = Argon2::default().hash_password_into(
+        password.as_bytes(),
+        salt.to_string().as_bytes(),
+        &mut output_key_material,
+    );
+
+    let key = Key::<Aes256Gcm>::from_slice(&output_key_material);
+    let cipher = Aes256Gcm::new(&key);
+
+    // Decode the nonce and encrypted data from base64
+    let nonce_bytes = STANDARD
+        .decode(&encrypted_wallet.nonce)
+        .expect("Failed to decode nonce");
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let encrypted_bytes = STANDARD
+        .decode(&encrypted_wallet.data)
+        .expect("Failed to decode encrypted data");
+
+    // Decrypt the wallet data
+    match cipher.decrypt(nonce, encrypted_bytes.as_ref()) {
+        Ok(decrypted_data) => {
+            // Deserialize the decrypted wallet JSON
+            let wallet: Wallet = serde_json::from_slice(&decrypted_data)
+                .expect("Failed to parse decrypted wallet JSON");
+
+            // Decode the hex string back into bytes
+            let private_key_bytes: Vec<u8> =
+                hex::decode(wallet.private_key).expect("Failed to decode private key hex");
+
+            // Convert bytes to Scalar
+            Scalar::from_repr(private_key_bytes.try_into().expect("Invalid key length"))
+                .expect("Failed to reconstruct Scalar from bytes")
+        }
+        Err(_) => {
+            println!("Failed to decrypt; try again!");
+            load_wallet()
+        }
+    }
 }

--- a/seedelf-cli/tests/setup_test.rs
+++ b/seedelf-cli/tests/setup_test.rs
@@ -1,0 +1,32 @@
+use seedelf_cli::setup::password_complexity_check;
+
+#[test]
+fn test_short_password() {
+    let pw: String = "i@G37xzM".to_string();
+    assert_eq!(password_complexity_check(pw), false)
+}
+
+
+#[test]
+fn test_no_lowercase() {
+    let pw: String = "I@G37XZM@QCGK3G".to_string();
+    assert_eq!(password_complexity_check(pw), false)
+}
+
+#[test]
+fn test_no_uppercase() {
+    let pw: String = "i@g37xzm@qcgk3g".to_string();
+    assert_eq!(password_complexity_check(pw), false)
+}
+
+#[test]
+fn test_no_special() {
+    let pw: String = "iaG37xzMaqcgk3g".to_string();
+    assert_eq!(password_complexity_check(pw), false)
+}
+
+#[test]
+fn test_good_password() {
+    let pw: String = "i@G37xzM@qcgk3g".to_string();
+    assert_eq!(password_complexity_check(pw), true)
+}


### PR DESCRIPTION
closes #41 

Secret keys are now encrypted using aes + argon2. Each endpoint will now prompt the user to decrypt the key. The secret key should never be displayed in the terminal.