### PR TITLE
132 copypasta pallas-wallet PrivateKey into the code base as its being deprecated

### DIFF
--- a/seedelf-cli/Cargo.toml
+++ b/seedelf-cli/Cargo.toml
@@ -27,7 +27,6 @@ pallas-crypto = "0.32.0"
 pallas-primitives = "0.32.0"
 pallas-traverse = "0.32.0"
 pallas-txbuilder = "0.32.0"
-pallas-wallet = "0.32.0"
 rand_core = { version = "0.6.0", features = ["std"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 rpassword = "7.3.1"

--- a/seedelf-cli/Cargo.toml
+++ b/seedelf-cli/Cargo.toml
@@ -21,12 +21,19 @@ dirs = "6.0.0"
 ff = "0.13.0"
 hex = "0.4.3"
 include_dir = "0.7.4"
-pallas-addresses = "0.32.0"
-pallas-codec = "0.32.0"
-pallas-crypto = "0.32.0"
-pallas-primitives = "0.32.0"
-pallas-traverse = "0.32.0"
-pallas-txbuilder = "0.32.0"
+#pallas-addresses = "0.32.0"
+#pallas-codec = "0.32.0"
+#pallas-crypto = "0.32.0"
+#pallas-primitives = "0.32.0"
+#pallas-traverse = "0.32.0"
+#pallas-txbuilder = "0.32.0"
+#
+pallas-addresses = { git = "https://github.com/txpipe/pallas", tag = "v1.0.0-alpha.1", package = "pallas-addresses" }
+pallas-codec =  { git = "https://github.com/txpipe/pallas", tag = "v1.0.0-alpha.1", package = "pallas-codec" }
+pallas-crypto =  { git = "https://github.com/txpipe/pallas", tag = "v1.0.0-alpha.1", package = "pallas-crypto" }
+pallas-primitives =  { git = "https://github.com/txpipe/pallas", tag = "v1.0.0-alpha.1", package = "pallas-primitives" }
+pallas-traverse =  { git = "https://github.com/txpipe/pallas", tag = "v1.0.0-alpha.1", package = "pallas-traverse" }
+pallas-txbuilder = { git = "https://github.com/txpipe/pallas", tag = "v1.0.0-alpha.1", package = "pallas-txbuilder" }
 rand_core = { version = "0.6.0", features = ["std"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 rpassword = "7.3.1"

--- a/seedelf-cli/Cargo.toml
+++ b/seedelf-cli/Cargo.toml
@@ -22,12 +22,12 @@ ff = "0.13.0"
 hex = "0.4.3"
 include_dir = "0.7.4"
 #
-#pallas-addresses = "0.32.0"
-#pallas-codec = "0.32.0"
-#pallas-crypto = "0.32.0"
-#pallas-primitives = "0.32.0"
-#pallas-traverse = "0.32.0"
-#pallas-txbuilder = "0.32.0"
+#pallas-addresses = "1.0.0"
+#pallas-codec = "1.0.0"
+#pallas-crypto = "1.0.0"
+#pallas-primitives = "1.0.0"
+#pallas-traverse = "1.0.0"
+#pallas-txbuilder = "1.0.0"
 #
 pallas-addresses = { git = "https://github.com/txpipe/pallas", tag = "v1.0.0-alpha.1", package = "pallas-addresses" }
 pallas-codec =  { git = "https://github.com/txpipe/pallas", tag = "v1.0.0-alpha.1", package = "pallas-codec" }

--- a/seedelf-cli/Cargo.toml
+++ b/seedelf-cli/Cargo.toml
@@ -21,6 +21,7 @@ dirs = "6.0.0"
 ff = "0.13.0"
 hex = "0.4.3"
 include_dir = "0.7.4"
+#
 #pallas-addresses = "0.32.0"
 #pallas-codec = "0.32.0"
 #pallas-crypto = "0.32.0"
@@ -34,6 +35,7 @@ pallas-crypto =  { git = "https://github.com/txpipe/pallas", tag = "v1.0.0-alpha
 pallas-primitives =  { git = "https://github.com/txpipe/pallas", tag = "v1.0.0-alpha.1", package = "pallas-primitives" }
 pallas-traverse =  { git = "https://github.com/txpipe/pallas", tag = "v1.0.0-alpha.1", package = "pallas-traverse" }
 pallas-txbuilder = { git = "https://github.com/txpipe/pallas", tag = "v1.0.0-alpha.1", package = "pallas-txbuilder" }
+#
 rand_core = { version = "0.6.0", features = ["std"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 rpassword = "7.3.1"

--- a/seedelf-cli/src/commands/create.rs
+++ b/seedelf-cli/src/commands/create.rs
@@ -6,7 +6,6 @@ use pallas_addresses::Address;
 use pallas_crypto::key::ed25519::SecretKey;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::assets::Assets;
@@ -250,11 +249,10 @@ pub async fn run(args: LabelArgs, network_flag: bool, variant: u64) -> Result<()
 
     // we can fake the signature here to get the correct tx size
     let fake_signer_secret_key: SecretKey = SecretKey::new(OsRng);
-    let fake_signer_private_key: PrivateKey = PrivateKey::from(fake_signer_secret_key);
 
     // we need the script size here
     let tx_size: u64 = intermediate_tx
-        .sign(fake_signer_private_key)
+        .sign(&fake_signer_secret_key)
         .unwrap()
         .tx_bytes
         .0

--- a/seedelf-cli/src/commands/create.rs
+++ b/seedelf-cli/src/commands/create.rs
@@ -6,7 +6,7 @@ use pallas_addresses::Address;
 use pallas_crypto::key::ed25519::SecretKey;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use pallas_wallet::PrivateKey;
+use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::assets::Assets;

--- a/seedelf-cli/src/commands/external/sweep.rs
+++ b/seedelf-cli/src/commands/external/sweep.rs
@@ -4,8 +4,6 @@ use pallas_addresses::Address;
 use pallas_crypto::key::ed25519::SecretKey;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use seedelf_cli::private_key::PrivateKey;
-
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::assets::Assets;
@@ -114,10 +112,9 @@ pub async fn run(network_flag: bool, variant: u64) -> Result<(), String> {
 
     // we can fake the signature here to get the correct tx size
     let fake_signer_secret_key: SecretKey = SecretKey::new(OsRng);
-    let fake_signer_private_key: PrivateKey = PrivateKey::from(fake_signer_secret_key);
 
     let tx_size: u64 = intermediate_tx
-        .sign(fake_signer_private_key)
+        .sign(&fake_signer_secret_key)
         .unwrap()
         .tx_bytes
         .0
@@ -174,8 +171,7 @@ pub async fn run(network_flag: bool, variant: u64) -> Result<(), String> {
 
     let tx: BuiltTransaction = raw_tx.build_conway_raw().unwrap();
 
-    let signed_tx_cbor: BuiltTransaction =
-        tx.sign(convert::secret_key_to_private_key(scalar)).unwrap();
+    let signed_tx_cbor: BuiltTransaction = tx.sign(&convert::scalar_to_secret_key(scalar)).unwrap();
 
     println!(
         "\nTx Cbor: {}",

--- a/seedelf-cli/src/commands/external/sweep.rs
+++ b/seedelf-cli/src/commands/external/sweep.rs
@@ -4,7 +4,8 @@ use pallas_addresses::Address;
 use pallas_crypto::key::ed25519::SecretKey;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use pallas_wallet::PrivateKey;
+use seedelf_cli::private_key::PrivateKey;
+
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::assets::Assets;

--- a/seedelf-cli/src/commands/fund.rs
+++ b/seedelf-cli/src/commands/fund.rs
@@ -5,7 +5,6 @@ use pallas_addresses::Address;
 use pallas_crypto::key::ed25519::SecretKey;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::assets::{Asset, Assets};
@@ -226,11 +225,10 @@ pub async fn run(args: FundArgs, network_flag: bool, variant: u64) -> Result<(),
 
     // we can fake the signature here to get the correct tx size
     let fake_signer_secret_key: SecretKey = SecretKey::new(OsRng);
-    let fake_signer_private_key: PrivateKey = PrivateKey::from(fake_signer_secret_key);
 
     // we need the script size here
     let tx_size: u64 = intermediate_tx
-        .sign(fake_signer_private_key)
+        .sign(&fake_signer_secret_key)
         .unwrap()
         .tx_bytes
         .0

--- a/seedelf-cli/src/commands/fund.rs
+++ b/seedelf-cli/src/commands/fund.rs
@@ -5,7 +5,7 @@ use pallas_addresses::Address;
 use pallas_crypto::key::ed25519::SecretKey;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use pallas_wallet::PrivateKey;
+use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::assets::{Asset, Assets};

--- a/seedelf-cli/src/commands/remove.rs
+++ b/seedelf-cli/src/commands/remove.rs
@@ -7,7 +7,7 @@ use pallas_crypto::key::ed25519::{PublicKey, SecretKey};
 use pallas_primitives::Hash;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use pallas_wallet::PrivateKey;
+use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::constants::{

--- a/seedelf-cli/src/commands/remove.rs
+++ b/seedelf-cli/src/commands/remove.rs
@@ -7,7 +7,6 @@ use pallas_crypto::key::ed25519::{PublicKey, SecretKey};
 use pallas_primitives::Hash;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::constants::{
@@ -18,6 +17,7 @@ use seedelf_cli::display::preprod_text;
 use seedelf_cli::koios::{
     UtxoResponse, evaluate_transaction, extract_bytes_with_logging, submit_tx, witness_collateral,
 };
+use seedelf_cli::private_key::PrivateKey;
 use seedelf_cli::register::Register;
 use seedelf_cli::schnorr::create_proof;
 use seedelf_cli::setup;
@@ -222,12 +222,11 @@ pub async fn run(args: RemoveArgs, network_flag: bool, variant: u64) -> Result<(
 
     // we can fake the signature here to get the correct tx size
     let fake_signer_secret_key: SecretKey = SecretKey::new(OsRng);
-    let fake_signer_private_key: PrivateKey = PrivateKey::from(fake_signer_secret_key);
 
     let tx_size: u64 = intermediate_tx
-        .sign(one_time_private_key)
+        .sign(&one_time_secret_key.clone())
         .unwrap()
-        .sign(fake_signer_private_key)
+        .sign(&fake_signer_secret_key)
         .unwrap()
         .tx_bytes
         .0
@@ -318,7 +317,7 @@ pub async fn run(args: RemoveArgs, network_flag: bool, variant: u64) -> Result<(
             let witness_vector: [u8; 64] = hex::decode(witness_sig).unwrap().try_into().unwrap();
 
             let signed_tx_cbor = tx
-                .sign(PrivateKey::from(one_time_secret_key.clone()))
+                .sign(&one_time_secret_key.clone())
                 .unwrap()
                 .add_signature(witness_public_key, witness_vector)
                 .unwrap();

--- a/seedelf-cli/src/commands/sweep.rs
+++ b/seedelf-cli/src/commands/sweep.rs
@@ -6,7 +6,6 @@ use pallas_crypto::key::ed25519::{PublicKey, SecretKey};
 use pallas_primitives::Hash;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::assets::{Asset, Assets};
@@ -20,6 +19,7 @@ use seedelf_cli::koios::{
     UtxoResponse, ada_handle_address, evaluate_transaction, extract_bytes_with_logging, submit_tx,
     witness_collateral,
 };
+use seedelf_cli::private_key::PrivateKey;
 use seedelf_cli::register::Register;
 use seedelf_cli::schnorr::create_proof;
 use seedelf_cli::setup;
@@ -381,12 +381,11 @@ pub async fn run(args: SweepArgs, network_flag: bool, variant: u64) -> Result<()
 
     // we can fake the signature here to get the correct tx size
     let fake_signer_secret_key: SecretKey = SecretKey::new(OsRng);
-    let fake_signer_private_key: PrivateKey = PrivateKey::from(fake_signer_secret_key);
 
     let tx_size: u64 = intermediate_tx
-        .sign(one_time_private_key)
+        .sign(&one_time_secret_key.clone())
         .unwrap()
-        .sign(fake_signer_private_key)
+        .sign(&fake_signer_secret_key)
         .unwrap()
         .tx_bytes
         .0
@@ -533,7 +532,7 @@ pub async fn run(args: SweepArgs, network_flag: bool, variant: u64) -> Result<()
             let witness_vector: [u8; 64] = hex::decode(witness_sig).unwrap().try_into().unwrap();
 
             let signed_tx_cbor = tx
-                .sign(PrivateKey::from(one_time_secret_key.clone()))
+                .sign(&one_time_secret_key.clone())
                 .unwrap()
                 .add_signature(witness_public_key, witness_vector)
                 .unwrap();

--- a/seedelf-cli/src/commands/sweep.rs
+++ b/seedelf-cli/src/commands/sweep.rs
@@ -6,7 +6,7 @@ use pallas_crypto::key::ed25519::{PublicKey, SecretKey};
 use pallas_primitives::Hash;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use pallas_wallet::PrivateKey;
+use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::assets::{Asset, Assets};
@@ -533,7 +533,7 @@ pub async fn run(args: SweepArgs, network_flag: bool, variant: u64) -> Result<()
             let witness_vector: [u8; 64] = hex::decode(witness_sig).unwrap().try_into().unwrap();
 
             let signed_tx_cbor = tx
-                .sign(pallas_wallet::PrivateKey::from(one_time_secret_key.clone()))
+                .sign(PrivateKey::from(one_time_secret_key.clone()))
                 .unwrap()
                 .add_signature(witness_public_key, witness_vector)
                 .unwrap();

--- a/seedelf-cli/src/commands/transfer.rs
+++ b/seedelf-cli/src/commands/transfer.rs
@@ -6,7 +6,7 @@ use pallas_crypto::key::ed25519::{PublicKey, SecretKey};
 use pallas_primitives::Hash;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use pallas_wallet::PrivateKey;
+use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::assets::{Asset, Assets};
@@ -424,7 +424,7 @@ pub async fn run(args: TransforArgs, network_flag: bool, variant: u64) -> Result
             let witness_vector: [u8; 64] = hex::decode(witness_sig).unwrap().try_into().unwrap();
 
             let signed_tx_cbor = tx
-                .sign(pallas_wallet::PrivateKey::from(one_time_secret_key.clone()))
+                .sign(PrivateKey::from(one_time_secret_key.clone()))
                 .unwrap()
                 .add_signature(witness_public_key, witness_vector)
                 .unwrap();

--- a/seedelf-cli/src/commands/transfer.rs
+++ b/seedelf-cli/src/commands/transfer.rs
@@ -6,7 +6,6 @@ use pallas_crypto::key::ed25519::{PublicKey, SecretKey};
 use pallas_primitives::Hash;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::assets::{Asset, Assets};
@@ -19,6 +18,7 @@ use seedelf_cli::display::preprod_text;
 use seedelf_cli::koios::{
     evaluate_transaction, extract_bytes_with_logging, submit_tx, witness_collateral,
 };
+use seedelf_cli::private_key::PrivateKey;
 use seedelf_cli::register::Register;
 use seedelf_cli::schnorr::create_proof;
 use seedelf_cli::setup;
@@ -298,12 +298,11 @@ pub async fn run(args: TransforArgs, network_flag: bool, variant: u64) -> Result
 
     // we can fake the signature here to get the correct tx size
     let fake_signer_secret_key: SecretKey = SecretKey::new(OsRng);
-    let fake_signer_private_key: PrivateKey = PrivateKey::from(fake_signer_secret_key);
 
     let tx_size: u64 = intermediate_tx
-        .sign(one_time_private_key)
+        .sign(&one_time_secret_key.clone())
         .unwrap()
-        .sign(fake_signer_private_key)
+        .sign(&fake_signer_secret_key)
         .unwrap()
         .tx_bytes
         .0
@@ -424,7 +423,7 @@ pub async fn run(args: TransforArgs, network_flag: bool, variant: u64) -> Result
             let witness_vector: [u8; 64] = hex::decode(witness_sig).unwrap().try_into().unwrap();
 
             let signed_tx_cbor = tx
-                .sign(PrivateKey::from(one_time_secret_key.clone()))
+                .sign(&one_time_secret_key.clone())
                 .unwrap()
                 .add_signature(witness_public_key, witness_vector)
                 .unwrap();

--- a/seedelf-cli/src/commands/util/extract.rs
+++ b/seedelf-cli/src/commands/util/extract.rs
@@ -4,7 +4,7 @@ use pallas_addresses::Address;
 use pallas_crypto::key::ed25519::SecretKey;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use pallas_wallet::PrivateKey;
+use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::data_structures;
 use seedelf_cli::koios::{UtxoResponse, address_utxos, evaluate_transaction, utxo_info};

--- a/seedelf-cli/src/commands/util/extract.rs
+++ b/seedelf-cli/src/commands/util/extract.rs
@@ -4,7 +4,6 @@ use pallas_addresses::Address;
 use pallas_crypto::key::ed25519::SecretKey;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::data_structures;
 use seedelf_cli::koios::{UtxoResponse, address_utxos, evaluate_transaction, utxo_info};
@@ -210,10 +209,9 @@ pub async fn run(args: ExtractArgs, network_flag: bool, variant: u64) -> Result<
 
     // we can fake the signature here to get the correct tx size
     let fake_signer_secret_key: SecretKey = SecretKey::new(OsRng);
-    let fake_signer_private_key: PrivateKey = PrivateKey::from(fake_signer_secret_key);
 
     let tx_size: u64 = intermediate_tx
-        .sign(fake_signer_private_key)
+        .sign(&fake_signer_secret_key)
         .unwrap()
         .tx_bytes
         .0

--- a/seedelf-cli/src/commands/util/mint.rs
+++ b/seedelf-cli/src/commands/util/mint.rs
@@ -6,7 +6,7 @@ use pallas_crypto::key::ed25519::{PublicKey, SecretKey};
 use pallas_primitives::Hash;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use pallas_wallet::PrivateKey;
+use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::assets::Assets;
@@ -435,7 +435,7 @@ pub async fn run(args: MintArgs, network_flag: bool, variant: u64) -> Result<(),
             let witness_vector: [u8; 64] = hex::decode(witness_sig).unwrap().try_into().unwrap();
 
             let signed_tx_cbor = tx
-                .sign(pallas_wallet::PrivateKey::from(one_time_secret_key.clone()))
+                .sign(PrivateKey::from(one_time_secret_key.clone()))
                 .unwrap()
                 .add_signature(witness_public_key, witness_vector)
                 .unwrap();

--- a/seedelf-cli/src/commands/util/mint.rs
+++ b/seedelf-cli/src/commands/util/mint.rs
@@ -6,7 +6,6 @@ use pallas_crypto::key::ed25519::{PublicKey, SecretKey};
 use pallas_primitives::Hash;
 use pallas_traverse::fees;
 use pallas_txbuilder::{BuildConway, BuiltTransaction, Input, Output, StagingTransaction};
-use seedelf_cli::private_key::PrivateKey;
 use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::assets::Assets;
@@ -19,6 +18,7 @@ use seedelf_cli::display::preprod_text;
 use seedelf_cli::koios::{
     UtxoResponse, evaluate_transaction, extract_bytes_with_logging, submit_tx, witness_collateral,
 };
+use seedelf_cli::private_key::PrivateKey;
 use seedelf_cli::register::Register;
 use seedelf_cli::schnorr::create_proof;
 use seedelf_cli::setup;
@@ -289,12 +289,12 @@ pub async fn run(args: MintArgs, network_flag: bool, variant: u64) -> Result<(),
 
     // we can fake the signature here to get the correct tx size
     let fake_signer_secret_key: SecretKey = SecretKey::new(OsRng);
-    let fake_signer_private_key: PrivateKey = PrivateKey::from(fake_signer_secret_key);
+    // let fake_signer_private_key: PrivateKey = PrivateKey::from(fake_signer_secret_key);
 
     let tx_size: u64 = intermediate_tx
-        .sign(one_time_private_key)
+        .sign(&one_time_secret_key)
         .unwrap()
-        .sign(fake_signer_private_key)
+        .sign(&fake_signer_secret_key)
         .unwrap()
         .tx_bytes
         .0
@@ -435,7 +435,7 @@ pub async fn run(args: MintArgs, network_flag: bool, variant: u64) -> Result<(),
             let witness_vector: [u8; 64] = hex::decode(witness_sig).unwrap().try_into().unwrap();
 
             let signed_tx_cbor = tx
-                .sign(PrivateKey::from(one_time_secret_key.clone()))
+                .sign(&one_time_secret_key.clone())
                 .unwrap()
                 .add_signature(witness_public_key, witness_vector)
                 .unwrap();

--- a/seedelf-cli/src/convert.rs
+++ b/seedelf-cli/src/convert.rs
@@ -2,7 +2,7 @@ use blstrs::Scalar;
 use cryptoxide::ed25519;
 use pallas_crypto::key::ed25519::SecretKey;
 use pallas_primitives::Hash;
-use pallas_wallet::PrivateKey;
+use crate::private_key::PrivateKey;
 
 pub fn scalar_to_secret_key(scalar: Scalar) -> SecretKey {
     let scalar_bytes: [u8; 32] = scalar.to_bytes_be();

--- a/seedelf-cli/src/convert.rs
+++ b/seedelf-cli/src/convert.rs
@@ -1,8 +1,8 @@
+use crate::private_key::PrivateKey;
 use blstrs::Scalar;
 use cryptoxide::ed25519;
 use pallas_crypto::key::ed25519::SecretKey;
 use pallas_primitives::Hash;
-use crate::private_key::PrivateKey;
 
 pub fn scalar_to_secret_key(scalar: Scalar) -> SecretKey {
     let scalar_bytes: [u8; 32] = scalar.to_bytes_be();

--- a/seedelf-cli/src/data_structures.rs
+++ b/seedelf-cli/src/data_structures.rs
@@ -1,8 +1,8 @@
 use hex;
 use hex::FromHex;
 use pallas_primitives::{
-    BoundedBytes, Fragment,
-    alonzo::{Constr, MaybeIndefArray, PlutusData},
+    BoundedBytes, Fragment, MaybeIndefArray,
+    alonzo::{Constr, PlutusData},
 };
 
 /// Creates a mint redeemer for a Plutus script.

--- a/seedelf-cli/src/lib.rs
+++ b/seedelf-cli/src/lib.rs
@@ -6,6 +6,7 @@ pub mod data_structures;
 pub mod display;
 pub mod hashing;
 pub mod koios;
+pub mod private_key;
 pub mod register;
 pub mod schnorr;
 pub mod setup;

--- a/seedelf-cli/src/private_key.rs
+++ b/seedelf-cli/src/private_key.rs
@@ -1,0 +1,38 @@
+use pallas_crypto::key::ed25519::{PublicKey, SecretKey, SecretKeyExtended, Signature};
+
+/// A standard or extended Ed25519 secret key
+pub enum PrivateKey {
+    Normal(SecretKey),
+    Extended(SecretKeyExtended),
+}
+
+impl PrivateKey {
+    pub fn public_key(&self) -> PublicKey {
+        match self {
+            Self::Normal(x) => x.public_key(),
+            Self::Extended(x) => x.public_key(),
+        }
+    }
+
+    pub fn sign<T>(&self, msg: T) -> Signature
+    where
+        T: AsRef<[u8]>,
+    {
+        match self {
+            Self::Normal(x) => x.sign(msg),
+            Self::Extended(x) => x.sign(msg),
+        }
+    }
+}
+
+impl From<SecretKey> for PrivateKey {
+    fn from(key: SecretKey) -> Self {
+        PrivateKey::Normal(key)
+    }
+}
+
+impl From<SecretKeyExtended> for PrivateKey {
+    fn from(key: SecretKeyExtended) -> Self {
+        PrivateKey::Extended(key)
+    }
+}

--- a/seedelf-cli/src/register.rs
+++ b/seedelf-cli/src/register.rs
@@ -3,8 +3,8 @@ use blstrs::{G1Affine, G1Projective, Scalar};
 use hex;
 use hex::FromHex;
 use pallas_primitives::{
-    BoundedBytes, Fragment,
-    alonzo::{Constr, MaybeIndefArray, PlutusData},
+    BoundedBytes, Fragment, MaybeIndefArray,
+    alonzo::{Constr, PlutusData},
 };
 use serde::{Deserialize, Serialize};
 

--- a/seedelf-cli/static/index.css
+++ b/seedelf-cli/static/index.css
@@ -17,11 +17,9 @@ body {
     width: 100%;
     margin: 0;
     padding: 0;
-    background-color: #222831;
+    background-color: #121212;
     color: #FEEFEE;
     font-family: 'Comfortaa', sans-serif;
-    background-image: -o-linear-gradient(#222831, #222831 50px, #121212 100px);
-    background-image: linear-gradient(#222831, #222831 50px, #121212 100px);
     overflow-x: hidden;
 }
 
@@ -64,7 +62,7 @@ section {
 }
 
 .nav-bar {
-    background-color: #2E3440;
+    background-color: #121212;
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
@@ -75,15 +73,8 @@ section {
     -ms-flex-align: center;
     align-items: center;
     width: 100%;
-    border-bottom: 1px solid transparent;
-    /* Adjust thickness as needed */
-    background-image: -webkit-gradient(linear, left top, right top, from(#2E3440), to(#222831)), -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.1)), to(transparent));
-    background-image: -o-linear-gradient(left, #2E3440, #222831), -o-linear-gradient(top, rgba(0, 0, 0, 0.1), transparent);
-    background-image: linear-gradient(to right, #2E3440, #222831), linear-gradient(to bottom, rgba(0, 0, 0, 0.1), transparent);
     background-origin: border-box;
     background-clip: content-box, border-box;
-    border-bottom-left-radius: 15px;
-    border-bottom-right-radius: 25px;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
 

--- a/seedelf-cli/static/index.html
+++ b/seedelf-cli/static/index.html
@@ -32,7 +32,8 @@
     </nav>
 
     <header class="centered">
-        <h3>Please select a wallet from the dropdown. This page will prompt you to sign a transaction with the wallet of your choice.</h3>
+        <h3>Please select a wallet from the dropdown. This page will prompt you to sign a transaction with the wallet of
+            your choice.</h3>
     </header>
 
     <main>

--- a/seedelf-cli/static/index.js
+++ b/seedelf-cli/static/index.js
@@ -54,9 +54,10 @@ async function initializePage() {
         const redeemer_part = injectedData.message.slice(injectedData.message.indexOf("a105"));
         complete_tx = injectedData.message.replace(redeemer_part, sig) + redeemer_part.slice(2);
       }
-
+      console.log("This should work");
       // lets use cardanoscan to view it
       let tx_hash = await wallet.submitTx(complete_tx);
+      console.log(tx_hash);
       txLinkElement.href = "https://" + injectedNetwork.network + "cardanoscan.io/transaction/" + tx_hash; // Set the href attribute
       txLinkElement.textContent = "View Transaction On Cardanoscan";
 

--- a/seedelf-cli/static/index.js
+++ b/seedelf-cli/static/index.js
@@ -54,10 +54,10 @@ async function initializePage() {
         const redeemer_part = injectedData.message.slice(injectedData.message.indexOf("a105"));
         complete_tx = injectedData.message.replace(redeemer_part, sig) + redeemer_part.slice(2);
       }
-      // 
+
+      // submitTx can return an error here so we want to catch that else it returns the tx hash
       const tx_hash = await wallet.submitTx(complete_tx);
-      console.log("TxId:", tx_hash);
-      
+
       // lets use cardanoscan to view it
       txLinkElement.href = "https://" + injectedNetwork.network + "cardanoscan.io/transaction/" + tx_hash; // Set the href attribute
       txLinkElement.textContent = "View Transaction On Cardanoscan";

--- a/seedelf-cli/static/index.js
+++ b/seedelf-cli/static/index.js
@@ -54,10 +54,11 @@ async function initializePage() {
         const redeemer_part = injectedData.message.slice(injectedData.message.indexOf("a105"));
         complete_tx = injectedData.message.replace(redeemer_part, sig) + redeemer_part.slice(2);
       }
-      console.log("This should work");
+      // 
+      const tx_hash = await wallet.submitTx(complete_tx);
+      console.log("TxId:", tx_hash);
+      
       // lets use cardanoscan to view it
-      let tx_hash = await wallet.submitTx(complete_tx);
-      console.log(tx_hash);
       txLinkElement.href = "https://" + injectedNetwork.network + "cardanoscan.io/transaction/" + tx_hash; // Set the href attribute
       txLinkElement.textContent = "View Transaction On Cardanoscan";
 

--- a/seedelf-cli/tests/data_structure_test.rs
+++ b/seedelf-cli/tests/data_structure_test.rs
@@ -1,7 +1,7 @@
 use hex::FromHex;
 use pallas_primitives::{
-    BoundedBytes, Fragment,
-    alonzo::{Constr, MaybeIndefArray, PlutusData},
+    BoundedBytes, Fragment, MaybeIndefArray,
+    alonzo::{Constr, PlutusData},
 };
 
 #[test]


### PR DESCRIPTION
Should close #132 

This PR is blocked until Pallas v1.0.0 is out. The `pallas_wallet` dependency is now built directly into the project, but has reduced functionality. Only the PrivateKey has been moved from the original implementation. Since PrivateKey is dropped, the TxBuilder had to be updated where applicable. Essentially, instead of passing in the PrivateKey that extracts the SecretKey for signing, we pass in the SecretKey with a signing trait.

This PR contains CSS fixes for the static site.