### PR TITLE
134 add query function to all endpoints that checks if the current version of the cli is up to date

### DIFF
--- a/seedelf-cli/Cargo.toml
+++ b/seedelf-cli/Cargo.toml
@@ -32,6 +32,7 @@ rand_core = { version = "0.6.0", features = ["std"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 rpassword = "7.3.1"
 self_update = { version = "0.42.0", features = ["archive-tar", "archive-zip"] }
+semver = "1.0.26"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.133"

--- a/seedelf-cli/README.md
+++ b/seedelf-cli/README.md
@@ -19,6 +19,8 @@ If you have [rust/cargo installed](https://www.rust-lang.org/tools/install), the
 cargo install seedelf-cli
 ```
 
+*The install command can be used to update the seedelf-cli!*
+
 ### Building From Source
 
 First, clone the repo and enter the cli subfolder.

--- a/seedelf-cli/src/commands/balance.rs
+++ b/seedelf-cli/src/commands/balance.rs
@@ -7,6 +7,7 @@ use seedelf_cli::setup;
 use seedelf_cli::utxos;
 
 pub async fn run(network_flag: bool, variant: u64) -> Result<(), Error> {
+    display::is_their_an_update().await;
     display::preprod_text(network_flag);
     display::block_number_and_time(network_flag).await;
 

--- a/seedelf-cli/src/commands/create.rs
+++ b/seedelf-cli/src/commands/create.rs
@@ -12,7 +12,7 @@ use seedelf_cli::address;
 use seedelf_cli::assets::Assets;
 use seedelf_cli::constants::{Config, get_config, plutus_v3_cost_model};
 use seedelf_cli::data_structures;
-use seedelf_cli::display::preprod_text;
+use seedelf_cli::display;
 use seedelf_cli::koios::{UtxoResponse, address_utxos, evaluate_transaction};
 use seedelf_cli::register::Register;
 use seedelf_cli::setup;
@@ -41,8 +41,8 @@ pub struct LabelArgs {
 }
 
 pub async fn run(args: LabelArgs, network_flag: bool, variant: u64) -> Result<(), String> {
-    // if preprod then print the preprod message
-    preprod_text(network_flag);
+    display::is_their_an_update().await;
+    display::preprod_text(network_flag);
 
     let config: Config = get_config(variant, network_flag).unwrap_or_else(|| {
         eprintln!("Error: Invalid Variant");

--- a/seedelf-cli/src/commands/external/balance.rs
+++ b/seedelf-cli/src/commands/external/balance.rs
@@ -10,6 +10,7 @@ use seedelf_cli::setup;
 use seedelf_cli::utxos;
 
 pub async fn run(network_flag: bool) -> Result<(), Error> {
+    display::is_their_an_update().await;
     display::preprod_text(network_flag);
     display::block_number_and_time(network_flag).await;
 

--- a/seedelf-cli/src/commands/external/sweep.rs
+++ b/seedelf-cli/src/commands/external/sweep.rs
@@ -10,7 +10,7 @@ use seedelf_cli::address;
 use seedelf_cli::assets::Assets;
 use seedelf_cli::constants::MAXIMUM_TOKENS_PER_UTXO;
 use seedelf_cli::convert;
-use seedelf_cli::display::preprod_text;
+use seedelf_cli::display;
 use seedelf_cli::koios::{UtxoResponse, submit_tx};
 use seedelf_cli::register::Register;
 use seedelf_cli::setup;
@@ -18,7 +18,8 @@ use seedelf_cli::transaction::wallet_minimum_lovelace_with_assets;
 use seedelf_cli::utxos;
 
 pub async fn run(network_flag: bool, variant: u64) -> Result<(), String> {
-    preprod_text(network_flag);
+    display::is_their_an_update().await;
+    display::preprod_text(network_flag);
     println!("\n{}", "Sweeping All External UTxOs".bright_blue(),);
 
     let wallet_addr: Address = address::wallet_contract(network_flag, variant);

--- a/seedelf-cli/src/commands/fund.rs
+++ b/seedelf-cli/src/commands/fund.rs
@@ -10,7 +10,7 @@ use rand_core::OsRng;
 use seedelf_cli::address;
 use seedelf_cli::assets::{Asset, Assets};
 use seedelf_cli::constants::MAXIMUM_TOKENS_PER_UTXO;
-use seedelf_cli::display::preprod_text;
+use seedelf_cli::display;
 use seedelf_cli::koios::{UtxoResponse, extract_bytes_with_logging};
 use seedelf_cli::register::Register;
 use seedelf_cli::transaction::wallet_minimum_lovelace_with_assets;
@@ -69,7 +69,8 @@ pub struct FundArgs {
 }
 
 pub async fn run(args: FundArgs, network_flag: bool, variant: u64) -> Result<(), String> {
-    preprod_text(network_flag);
+    display::is_their_an_update().await;
+    display::preprod_text(network_flag);
 
     // its ok not to define lovelace but in that case an asset has to be define
     if args.lovelace.is_none()

--- a/seedelf-cli/src/commands/remove.rs
+++ b/seedelf-cli/src/commands/remove.rs
@@ -14,7 +14,7 @@ use seedelf_cli::constants::{
     COLLATERAL_HASH, COLLATERAL_PUBLIC_KEY, Config, get_config, plutus_v3_cost_model,
 };
 use seedelf_cli::data_structures;
-use seedelf_cli::display::preprod_text;
+use seedelf_cli::display;
 use seedelf_cli::koios::{
     UtxoResponse, evaluate_transaction, extract_bytes_with_logging, submit_tx, witness_collateral,
 };
@@ -40,7 +40,8 @@ pub struct RemoveArgs {
 }
 
 pub async fn run(args: RemoveArgs, network_flag: bool, variant: u64) -> Result<(), String> {
-    preprod_text(network_flag);
+    display::is_their_an_update().await;
+    display::preprod_text(network_flag);
 
     let config: Config = get_config(variant, network_flag).unwrap_or_else(|| {
         eprintln!("Error: Invalid Variant");

--- a/seedelf-cli/src/commands/sweep.rs
+++ b/seedelf-cli/src/commands/sweep.rs
@@ -15,7 +15,7 @@ use seedelf_cli::constants::{
     plutus_v3_cost_model,
 };
 use seedelf_cli::data_structures;
-use seedelf_cli::display::preprod_text;
+use seedelf_cli::display;
 use seedelf_cli::koios::{
     UtxoResponse, ada_handle_address, evaluate_transaction, extract_bytes_with_logging, submit_tx,
     witness_collateral,
@@ -88,7 +88,8 @@ pub struct SweepArgs {
 }
 
 pub async fn run(args: SweepArgs, network_flag: bool, variant: u64) -> Result<(), String> {
-    preprod_text(network_flag);
+    display::is_their_an_update().await;
+    display::preprod_text(network_flag);
 
     let config: Config = get_config(variant, network_flag).unwrap_or_else(|| {
         eprintln!("Error: Invalid Variant");

--- a/seedelf-cli/src/commands/transfer.rs
+++ b/seedelf-cli/src/commands/transfer.rs
@@ -15,7 +15,7 @@ use seedelf_cli::constants::{
     plutus_v3_cost_model,
 };
 use seedelf_cli::data_structures;
-use seedelf_cli::display::preprod_text;
+use seedelf_cli::display;
 use seedelf_cli::koios::{
     evaluate_transaction, extract_bytes_with_logging, submit_tx, witness_collateral,
 };
@@ -71,7 +71,8 @@ pub struct TransforArgs {
 }
 
 pub async fn run(args: TransforArgs, network_flag: bool, variant: u64) -> Result<(), String> {
-    preprod_text(network_flag);
+    display::is_their_an_update().await;
+    display::preprod_text(network_flag);
 
     let config: Config = get_config(variant, network_flag).unwrap_or_else(|| {
         eprintln!("Error: Invalid Variant");

--- a/seedelf-cli/src/commands/util/age.rs
+++ b/seedelf-cli/src/commands/util/age.rs
@@ -2,7 +2,7 @@ use chrono::Utc;
 use clap::Args;
 use colored::Colorize;
 use seedelf_cli::constants::{Config, get_config};
-use seedelf_cli::display::preprod_text;
+use seedelf_cli::display;
 use seedelf_cli::koios::{History, asset_history};
 
 /// Struct to hold command-specific arguments
@@ -55,7 +55,8 @@ fn format_duration(seconds: i64) -> String {
 }
 
 pub async fn run(args: AgeArgs, network_flag: bool, variant: u64) -> Result<(), String> {
-    preprod_text(network_flag);
+    display::is_their_an_update().await;
+    display::preprod_text(network_flag);
     let config: Config = get_config(variant, network_flag).unwrap_or_else(|| {
         eprintln!("Error: Invalid Variant");
         std::process::exit(1);

--- a/seedelf-cli/src/commands/util/extract.rs
+++ b/seedelf-cli/src/commands/util/extract.rs
@@ -12,7 +12,7 @@ use seedelf_cli::koios::{UtxoResponse, address_utxos, evaluate_transaction, utxo
 use seedelf_cli::address;
 use seedelf_cli::assets::Assets;
 use seedelf_cli::constants::{Config, get_config, plutus_v3_cost_model};
-use seedelf_cli::display::preprod_text;
+use seedelf_cli::display;
 use seedelf_cli::transaction::{
     address_minimum_lovelace_with_assets, extract_budgets, total_computation_fee,
     wallet_reference_utxo,
@@ -37,7 +37,8 @@ pub struct ExtractArgs {
 }
 
 pub async fn run(args: ExtractArgs, network_flag: bool, variant: u64) -> Result<(), String> {
-    preprod_text(network_flag);
+    display::is_their_an_update().await;
+    display::preprod_text(network_flag);
 
     let config: Config = get_config(variant, network_flag).unwrap_or_else(|| {
         eprintln!("Error: Invalid Variant");

--- a/seedelf-cli/src/commands/util/find.rs
+++ b/seedelf-cli/src/commands/util/find.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use colored::Colorize;
-use seedelf_cli::display::preprod_text;
+use seedelf_cli::display;
 use seedelf_cli::utxos::find_and_print_all_seedelfs;
 
 /// Struct to hold command-specific arguments
@@ -17,7 +17,8 @@ pub struct FindArgs {
 }
 
 pub async fn run(args: FindArgs, network_flag: bool, variant: u64) -> Result<(), String> {
-    preprod_text(network_flag);
+    display::is_their_an_update().await;
+    display::preprod_text(network_flag);
     println!(
         "\n{} {}",
         "Finding All Seedelfs Containing:".bright_blue(),

--- a/seedelf-cli/src/commands/util/history.rs
+++ b/seedelf-cli/src/commands/util/history.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use colored::Colorize;
 use pallas_addresses::Address;
 use seedelf_cli::address;
-use seedelf_cli::display::preprod_text;
+use seedelf_cli::display;
 use seedelf_cli::koios::TxResponse;
 use seedelf_cli::koios::address_transactions;
 use seedelf_cli::setup;
@@ -21,7 +21,8 @@ pub struct HistoryArgs {
 }
 
 pub async fn run(args: HistoryArgs, network_flag: bool, variant: u64) -> Result<(), String> {
-    preprod_text(network_flag);
+    display::is_their_an_update().await;
+    display::preprod_text(network_flag);
 
     let scalar: Scalar = setup::load_wallet();
 

--- a/seedelf-cli/src/commands/util/migrate.rs
+++ b/seedelf-cli/src/commands/util/migrate.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use colored::Colorize;
 use seedelf_cli::constants::VARIANT;
-use seedelf_cli::display::preprod_text;
+use seedelf_cli::display;
 
 /// Struct to hold command-specific arguments
 #[derive(Args)]
@@ -11,13 +11,14 @@ pub struct MigrateArgs {
     from_variant: u64,
 }
 
-pub fn run(args: MigrateArgs, network_flag: bool) -> Result<(), String> {
+pub async fn run(args: MigrateArgs, network_flag: bool) -> Result<(), String> {
     // starts a variant 1
     if args.from_variant == 0 || args.from_variant >= VARIANT {
         return Err("Incorrect Migration Variant".to_string());
     }
 
-    preprod_text(network_flag);
+    display::is_their_an_update().await;
+    display::preprod_text(network_flag);
 
     println!(
         "{}",

--- a/seedelf-cli/src/commands/util/mint.rs
+++ b/seedelf-cli/src/commands/util/mint.rs
@@ -15,7 +15,7 @@ use seedelf_cli::constants::{
     plutus_v3_cost_model,
 };
 use seedelf_cli::data_structures;
-use seedelf_cli::display::preprod_text;
+use seedelf_cli::display;
 use seedelf_cli::koios::{
     UtxoResponse, evaluate_transaction, extract_bytes_with_logging, submit_tx, witness_collateral,
 };
@@ -42,8 +42,8 @@ pub struct MintArgs {
 }
 
 pub async fn run(args: MintArgs, network_flag: bool, variant: u64) -> Result<(), String> {
-    // if preprod then print the preprod message
-    preprod_text(network_flag);
+    display::is_their_an_update().await;
+    display::preprod_text(network_flag);
 
     let config: Config = get_config(variant, network_flag).unwrap_or_else(|| {
         eprintln!("Error: Invalid Variant");

--- a/seedelf-cli/src/commands/util/mod.rs
+++ b/seedelf-cli/src/commands/util/mod.rs
@@ -66,7 +66,7 @@ pub async fn run(args: UtilArgs, preprod_flag: bool, variant: u64) {
             }
         }
         UtilCommands::Migrate(args) => {
-            if let Err(err) = migrate::run(args, preprod_flag) {
+            if let Err(err) = migrate::run(args, preprod_flag).await {
                 eprintln!("Error: {}", err);
             }
         }

--- a/seedelf-cli/src/commands/util/statistics.rs
+++ b/seedelf-cli/src/commands/util/statistics.rs
@@ -1,9 +1,10 @@
 use colored::Colorize;
-use seedelf_cli::display::preprod_text;
+use seedelf_cli::display;
 use seedelf_cli::utxos::count_lovelace_and_utxos;
 
 pub async fn run(network_flag: bool, variant: u64) -> Result<(), String> {
-    preprod_text(network_flag);
+    display::is_their_an_update().await;
+    display::preprod_text(network_flag);
     println!("\n{}", "Seedelf Statistics".bright_blue());
     count_lovelace_and_utxos(network_flag, variant).await;
     // other things can go here

--- a/seedelf-cli/src/commands/welcome.rs
+++ b/seedelf-cli/src/commands/welcome.rs
@@ -1,6 +1,8 @@
 use colored::Colorize;
+use seedelf_cli::display::is_their_an_update;
 
-pub fn run() {
+pub async fn run() {
+    is_their_an_update().await;
     println!(
         "\n{} 🌱🧝\n{}",
         "\nWelcome to seedelf-cli!".bright_white(),
@@ -9,9 +11,14 @@ pub fn run() {
     println!("{}", "\nThe Seedelf wallet is a stealth wallet protocol that hides the receiver and spender using a non-interactive variant of Schnorr's Σ-protocol for the Discrete Logarithm Relation.".bright_green());
     println!("\n 😀\n");
     println!(
-        "{} {}",
+        "{}\n\n{}",
         "Start your journey by creating a Seedelf with the cli command:".bright_purple(),
-        "create".bright_cyan()
+        "seedelf-cli create --address <ADDRESS>".bright_cyan()
+    );
+    println!(
+        "\n{} {}",
+        "You can view all the available functions with:".bright_yellow(),
+        "seedelf-cli help".bright_blue()
     );
     println!(
         "{}",

--- a/seedelf-cli/src/display.rs
+++ b/seedelf-cli/src/display.rs
@@ -1,7 +1,32 @@
 use crate::constants::{Config, get_config};
 use crate::koios::{contains_policy_id, credential_utxos, extract_bytes_with_logging, tip};
+use crate::version_control::{compare_versions, get_latest_version};
 use blstrs::Scalar;
 use colored::Colorize;
+
+pub async fn is_their_an_update() {
+    match get_latest_version().await {
+        Ok(tag) => {
+            if !compare_versions(env!("CARGO_PKG_VERSION"), &tag) {
+                println!(
+                    "\n{} {}\n{}",
+                    "A new version is available:".bold().bright_blue(),
+                    tag.yellow(),
+                    "Please update to the newest version of Seedelf"
+                        .bold()
+                        .bright_blue(),
+                );
+            }
+        }
+        Err(err) => {
+            eprintln!(
+                "Failed to fetch newest version: {}\nWait a few moments and try again.",
+                err
+            );
+            std::process::exit(1);
+        }
+    }
+}
 
 pub async fn block_number_and_time(network_flag: bool) {
     match tip(network_flag).await {

--- a/seedelf-cli/src/lib.rs
+++ b/seedelf-cli/src/lib.rs
@@ -11,4 +11,5 @@ pub mod schnorr;
 pub mod setup;
 pub mod transaction;
 pub mod utxos;
+pub mod version_control;
 pub mod web_server;

--- a/seedelf-cli/src/main.rs
+++ b/seedelf-cli/src/main.rs
@@ -54,7 +54,7 @@ async fn main() {
 
     match cli.command {
         Some(Commands::Welcome) => {
-            commands::welcome::run();
+            commands::welcome::run().await;
         }
         Some(Commands::Balance) => {
             if let Err(err) = commands::balance::run(cli.preprod, cli.variant).await {

--- a/seedelf-cli/src/version_control.rs
+++ b/seedelf-cli/src/version_control.rs
@@ -1,0 +1,32 @@
+use reqwest::Client;
+use semver::Version;
+use serde_json::Value;
+
+pub async fn get_latest_version() -> Result<String, Box<dyn std::error::Error>> {
+    let url = "https://api.github.com/repos/logical-mechanism/Seedelf-Wallet/releases/latest";
+
+    let client = Client::new();
+    let response = client
+        .get(url)
+        .header("User-Agent", "seedelf") // GitHub requires this
+        .send()
+        .await?
+        .error_for_status()?; // fails early if status isn't 200 OK
+
+    let json: Value = response.json().await?;
+
+    let tag = json
+        .get("tag_name")
+        .and_then(|v| v.as_str())
+        .ok_or("tag_name not found")?;
+
+    Ok(tag.to_string())
+}
+
+// Helper function to compare versions
+pub fn compare_versions(local: &str, latest: &str) -> bool {
+    match (Version::parse(local), Version::parse(latest)) {
+        (Ok(local_version), Ok(latest_version)) => local_version >= latest_version,
+        _ => false, // If either version can't be parsed, assume it's not up to date
+    }
+}

--- a/seedelf-cli/tests/display_test.rs
+++ b/seedelf-cli/tests/display_test.rs
@@ -1,4 +1,10 @@
-use seedelf_cli::display::hex_to_ascii;
+use seedelf_cli::display::{hex_to_ascii, is_their_an_update};
+
+#[tokio::test]
+async fn test_version_control_display() {
+    is_their_an_update().await
+}
+
 #[test]
 fn test_label_extraction() {
     let seedelf: String =

--- a/seedelf-cli/tests/version_control_test.rs
+++ b/seedelf-cli/tests/version_control_test.rs
@@ -1,0 +1,24 @@
+use seedelf_cli::version_control::{compare_versions, get_latest_version};
+
+#[test]
+fn same_version() {
+    assert_eq!(compare_versions("0.4.6", "0.4.6"), true)
+}
+
+#[test]
+fn need_to_update() {
+    assert_eq!(compare_versions("0.4.5", "0.4.6"), false)
+}
+
+#[test]
+fn major_minor_tests() {
+    assert_eq!(compare_versions("0.5.5", "0.4.6"), true)
+}
+
+#[tokio::test]
+async fn get_latest_version_from_github() {
+    match get_latest_version().await {
+        Ok(tag) => assert_eq!(tag, env!("CARGO_PKG_VERSION")),
+        Err(e) => panic!("Failed to fetch latest version: {}", e),
+    }
+}


### PR DESCRIPTION
should close #134 

It will now query GitHub for the latest tag and compare its version against the `CARGO_PKG_VERSION`.