### PR TITLE
144 add custom registry info for util mint

### DIFF
--- a/seedelf-cli/src/commands/util/mint.rs
+++ b/seedelf-cli/src/commands/util/mint.rs
@@ -39,6 +39,22 @@ pub struct MintArgs {
         display_order = 1
     )]
     label: Option<String>,
+
+    #[arg(
+        short = 'g',
+        long,
+        help = "A generator point in G1.",
+        display_order = 2
+    )]
+    generator: Option<String>,
+
+    #[arg(
+        short = 'p',
+        long,
+        help = "A public value computed as `generator * sk`",
+        display_order = 3
+    )]
+    public_value: Option<String>,
 }
 
 pub async fn run(args: MintArgs, network_flag: bool, variant: u64) -> Result<(), String> {

--- a/seedelf-cli/src/commands/util/mint.rs
+++ b/seedelf-cli/src/commands/util/mint.rs
@@ -136,7 +136,8 @@ pub async fn run(args: MintArgs, network_flag: bool, variant: u64) -> Result<(),
     let datum_vector: Vec<u8> = if args.generator.is_none() && args.public_value.is_none() {
         Register::create(scalar).rerandomize().to_vec()
     } else {
-        // both have to be some
+        // both have to be some to get to this point
+        // requires should catch the mix cases
         let new_register: Register = Register::new(
             args.generator.unwrap_or_default(),
             args.public_value.unwrap_or_default(),

--- a/seedelf-cli/src/register.rs
+++ b/seedelf-cli/src/register.rs
@@ -161,4 +161,29 @@ impl Register {
 
         hex::encode(g_x.to_compressed()) == self.public_value
     }
+
+    pub fn is_valid(&self) -> bool {
+        // Decode and decompress generator
+        let g1: G1Affine = G1Affine::from_compressed(
+            &hex::decode(&self.generator)
+                .expect("Failed to decode generator hex")
+                .try_into()
+                .expect("Invalid generator length"),
+        )
+        .expect("Failed to decompress generator");
+
+        // Decode and decompress public_value
+        let u: G1Affine = G1Affine::from_compressed(
+            &hex::decode(&self.public_value)
+                .expect("Failed to decode public value hex")
+                .try_into()
+                .expect("Invalid public value length"),
+        )
+        .expect("Failed to decompress public value");
+
+        g1.is_on_curve().into()
+            && g1.is_torsion_free().into()
+            && u.is_on_curve().into()
+            && u.is_torsion_free().into()
+    }
 }

--- a/seedelf-cli/tests/register_test.rs
+++ b/seedelf-cli/tests/register_test.rs
@@ -25,6 +25,7 @@ fn random_register() {
 fn is_random_register_valid_test() {
     let sk: Scalar = random_scalar();
     let datum: Register = Register::create(sk);
+    println!("{datum:?}");
     assert_eq!(datum.is_valid(), true);
 }
 

--- a/seedelf-cli/tests/register_test.rs
+++ b/seedelf-cli/tests/register_test.rs
@@ -1,0 +1,44 @@
+use blstrs::Scalar;
+use seedelf_cli::register::Register;
+use seedelf_cli::schnorr::random_scalar;
+
+#[test]
+fn default_register() {
+    let sk: Scalar = Scalar::from(1u64);
+    let datum: Register = Register::create(sk);
+    let generator_hex = "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb";
+    assert_eq!(datum.generator, generator_hex);
+    assert_eq!(datum.public_value, generator_hex);
+}
+
+#[test]
+fn random_register() {
+    let sk: Scalar = Scalar::from(18446744073709551606u64);
+    let datum: Register = Register::create(sk);
+    let generator_hex = "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb";
+    let public_value_hex = "82dcf46570656ca0d6fb143b8e7c2816b20cb1a6434ca4c8c95c624443c22c9e1d40ad0df5de088b19a4b44b685b8475";
+    assert_eq!(datum.generator, generator_hex);
+    assert_eq!(datum.public_value, public_value_hex);
+}
+
+#[test]
+fn is_random_register_valid_test() {
+    let sk: Scalar = random_scalar();
+    let datum: Register = Register::create(sk);
+    assert_eq!(datum.is_valid(), true);
+}
+
+#[test]
+fn valid_is_owned() {
+    let sk: Scalar = random_scalar();
+    let datum: Register = Register::create(sk).rerandomize();
+    assert!(datum.is_owned(sk))
+}
+
+#[test]
+fn invalid_is_owned() {
+    let sk1: Scalar = random_scalar();
+    let sk2: Scalar = random_scalar();
+    let datum: Register = Register::create(sk1).rerandomize();
+    assert!(!datum.is_owned(sk2))
+}

--- a/seedelf-cli/tests/schnorr_test.rs
+++ b/seedelf-cli/tests/schnorr_test.rs
@@ -47,25 +47,6 @@ fn valid_randomized_schnorr_proof() {
 }
 
 #[test]
-fn default_register() {
-    let sk: Scalar = Scalar::from(1u64);
-    let datum: Register = Register::create(sk);
-    let generator_hex = "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb";
-    assert_eq!(datum.generator, generator_hex);
-    assert_eq!(datum.public_value, generator_hex);
-}
-
-#[test]
-fn random_register() {
-    let sk: Scalar = Scalar::from(18446744073709551606u64);
-    let datum: Register = Register::create(sk);
-    let generator_hex = "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb";
-    let public_value_hex = "82dcf46570656ca0d6fb143b8e7c2816b20cb1a6434ca4c8c95c624443c22c9e1d40ad0df5de088b19a4b44b685b8475";
-    assert_eq!(datum.generator, generator_hex);
-    assert_eq!(datum.public_value, public_value_hex);
-}
-
-#[test]
 fn create_proof_and_test_it() {
     let sk: Scalar = Scalar::from(18446744073709551606u64);
     let datum: Register = Register::create(sk);
@@ -113,19 +94,4 @@ fn create_random_proof_rerandomize_it_and_test_it() {
         &g_r_b,
         bound
     ))
-}
-
-#[test]
-fn valid_is_owned() {
-    let sk: Scalar = random_scalar();
-    let datum: Register = Register::create(sk).rerandomize();
-    assert!(datum.is_owned(sk))
-}
-
-#[test]
-fn invalid_is_owned() {
-    let sk1: Scalar = random_scalar();
-    let sk2: Scalar = random_scalar();
-    let datum: Register = Register::create(sk1).rerandomize();
-    assert!(!datum.is_owned(sk2))
 }


### PR DESCRIPTION
There are optional fields that can take in a generator and a public value. The points are checked for validity but not if the Dlog relation holds. That must be done off-chain. The `util/mint` endpoint should now allow arbitrary seedelfs to be minted from inside the contract. 

This should close #144